### PR TITLE
Register "magnet" URI scheme handler

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -1,3 +1,5 @@
+navigator.registerProtocolHandler 'magnet', window.location.origin + '#%s', 'βTorrent'
+
 trackers = [
   'wss://tracker.btorrent.xyz'
   'wss://tracker.webtorrent.io'


### PR DESCRIPTION
When a web browser executes this code, it should display a prompt to the user, asking permission to allow the web application to register as a handler for the URI scheme.