### PR TITLE
feat: add wss://open.ftorrent.com tracker

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 import WebTorrent from 'https://cdn.jsdelivr.net/npm/webtorrent@3/dist/webtorrent.min.js'
 
 const VERSION = '2'
-const trackers = ['wss://tracker.btorrent.xyz', 'wss://tracker.openwebtorrent.com']
+const trackers = ['wss://tracker.btorrent.xyz', 'wss://tracker.openwebtorrent.com', 'wss://open.ftorrent.com']
 const rtcConfig = {
   'iceServers': [
     {


### PR DESCRIPTION
Hi Diego — nice to meet you. βTorrent quietly turning ten while still running current webtorrent is kind of wonderful — and since you run tracker.btorrent.xyz as well, this comes operator-to-operator: I'm connecting open.ftorrent.com, the open tracker at the start of my broader decentralized computing project, to more of the ecosystem it can serve.

This adds `wss://open.ftorrent.com` to the tracker list.

It's an [Aquatic](https://github.com/greatest-ape/aquatic) WebSocket tracker — the same software as `tracker.webtorrent.dev` — that I operate, with the deployment public at [zootella/ftorrent](https://github.com/zootella/ftorrent/tree/master/open) and live stats at [open.ftorrent.com](https://open.ftorrent.com/) (machine-readable: [page.json](https://open.ftorrent.com/page.json)). Happy to have it removed if it ever misbehaves.
